### PR TITLE
Mark string methods as public.

### DIFF
--- a/uuid.zig
+++ b/uuid.zig
@@ -22,12 +22,12 @@ pub const UUID = struct {
         return uuid;
     }
 
-    fn to_string(self: UUID,slice: []u8) void {
-        var string:[36]u8 = format_uuid(self);
+    pub fn to_string(self: UUID, slice: []u8) void {
+        var string: [36]u8 = format_uuid(self);
         std.mem.copy(u8, slice, &string);
     }
 
-    fn format_uuid(self: UUID) [36]u8 {
+    pub fn format_uuid(self: UUID) [36]u8 {
         var buf: [36]u8 = undefined;
         buf[8] = '-';
         buf[13] = '-';
@@ -161,8 +161,8 @@ test "check to_string works" {
     uuid1.to_string(&string1);
     uuid1.to_string(&string2);
 
-    std.debug.print("\nUUID {s} \n", .{uuid1});
-    std.debug.print("\nFirst  call to_string {s} \n", .{string1});
-    std.debug.print("Second call to_string {s} \n", .{string2});
+    std.log.debug("\nUUID {s} \n", .{uuid1});
+    std.log.debug("\nFirst  call to_string {s} \n", .{string1});
+    std.log.debug("Second call to_string {s} \n", .{string2});
     try testing.expectEqual(string1, string2);
 }


### PR DESCRIPTION
The two string helpers (to_string and format_uuid) were not marked "pub", and therefore couldn't be called on an UUID created outside the module.

Since these method aren't called anywhere inside the struct, and looking at the test, I assume this is not the intended behavior.

I'm fairly new to zig, so maybe this broke in a recent release (I'm using 0.11.0) ?

Also, the associated tests were failing, which seemed to be caused by writing to stdout. Using `std.log` instead of `std.debug.print` seems to fix the issue.